### PR TITLE
Fix for publising in Laravel 5.4.

### DIFF
--- a/src/LightspeedServiceProvider.php
+++ b/src/LightspeedServiceProvider.php
@@ -23,8 +23,9 @@ class LightspeedServiceProvider extends ServiceProvider
     {
         $this->mergeConfigFrom(__DIR__.'/../config/lightspeed-api.php', 'lightspeed-api');
 
-        $this->app['lightspeedapi'] = $this->app->share(function ($app) {
-            return new Lightspeed($app['config']['lightspeed-api']);
+       $this->app->singleton(Lightspeed::class, function($app) {
+            $config = $app['config']['Lightspeed'];
+            return new Lightspeed($config);
         });
     }
 }


### PR DESCRIPTION
Replace share method with singleton method for Laravel 5.4. 
Share method is deprecated in Laravel 5.4. 